### PR TITLE
Removing reference to SignalR-Client-Swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ Not yet, sorry.
 # Alternatives
 - [SwiftR](https://github.com/adamhartford/SwiftR) SignalR client in JavaScript, running in a WebView, wrapped in Swift.
 - [SignalR-ObjC](https://github.com/DyKnow/SignalR-ObjC) SignalR client in Objective-C.
-- [SignalR-Client-Swift](https://github.com/moozzyk/SignalR-Client-Swift) Tiny SignalR client in Swift from a Member of the SignalR Dev-Team at Microsoft. Lacks some feature.
+
 
 


### PR DESCRIPTION
https://github.com/moozzyk/SignalR-Client-Swift is work in progress for the client for the Asp.NET Core SignalR. It is not intended to work with SignalR 2.x server hence is not an alternative but a different product.